### PR TITLE
TEL-979 Remove graphite-rollup cfg

### DIFF
--- a/clickhouse_config_in_zookeeper.py
+++ b/clickhouse_config_in_zookeeper.py
@@ -11,25 +11,20 @@ def lambda_handler(event, context):
     # Get zookeeper IPs from ec2
     # Get clickhouse-server IPs and shards from ec2
     # Write remote server config to Zookeeper
-    # Write graphite-rollup config to Zookeeper
 
     ec2 = get_ec2_client()
     log.debug('get_ec2_client successful')
 
     zookeeper = get_zookeeper_client(ec2)
 
-    graphite_rollup_path, remote_server_path = ensure_paths_exist(zookeeper)
+    remote_server_path = ensure_path_exists(zookeeper)
 
     remote_server_xml, cluster_definition = generate_remote_servers_xml(ec2)
-
-    graphite_rollup = get_graphite_rollup_xml()
 
     zookeeper.set(remote_server_path, remote_server_xml)
     log.info(
         'remote_servers added to Zookeeper successfully for cluster definition'
     )
-    zookeeper.set(graphite_rollup_path, graphite_rollup)
-    log.debug('graphite_rollup added to Zookeeper successfully')
 
     zookeeper.stop()
     log.debug('Disconnected from zookeeper.')
@@ -38,16 +33,12 @@ def lambda_handler(event, context):
     }
 
 
-def ensure_paths_exist(zookeeper):
+def ensure_path_exists(zookeeper):
     remote_server_path = 'clickhouse.config.remote_servers'
-    graphite_rollup_path = 'clickhouse.config.graphite_rollup'
     zookeeper.ensure_path(remote_server_path)
     log.debug("{0} exists: {1}".format(remote_server_path,
                                        zookeeper.exists(remote_server_path)))
-    zookeeper.ensure_path(graphite_rollup_path)
-    log.debug("{0} exists: {1}".format(graphite_rollup_path,
-                                       zookeeper.exists(graphite_rollup_path)))
-    return graphite_rollup_path, remote_server_path
+    return remote_server_path
 
 
 def get_clickhouse_cluster_definition(ec2_client):
@@ -128,34 +119,6 @@ def generate_remote_servers_xml(ec2):
     log.info("Generated remote_servers xml for cluster {0}"
              .format(cluster_definition))
     return remote_server_xml, cluster_definition
-
-
-def get_graphite_rollup_xml():
-    xml = b"""        <path_column_name>Path</path_column_name>
-        <time_column_name>Time</time_column_name>
-        <value_column_name>Value</value_column_name>
-        <version_column_name>Timestamp</version_column_name>
-        <pattern>
-            <regexp>^collectd\..*\.mongo-.*\.(file_size-data|file_size-index|file_size-storage|gauge-collections|gauge-indexes|gauge-num_extents|gauge-object_count)$</regexp>
-            <function>avg</function>
-            <retention>
-                <age>0</age>
-                <precision>1200</precision>
-            </retention>
-        </pattern>
-        <default>
-            <function>avg</function>
-            <retention>
-                <age>0</age>
-                <precision>60</precision>
-            </retention>
-            <retention>
-                <age>604800</age>
-                <precision>600</precision>
-            </retention>
-        </default>"""
-    return xml
-
 
 def get_ec2_client():
     return boto3.client('ec2', 'eu-west-2')

--- a/clickhouse_config_in_zookeeper.py
+++ b/clickhouse_config_in_zookeeper.py
@@ -120,5 +120,6 @@ def generate_remote_servers_xml(ec2):
              .format(cluster_definition))
     return remote_server_xml, cluster_definition
 
+
 def get_ec2_client():
     return boto3.client('ec2', 'eu-west-2')

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,0 +1,4 @@
+leakDetectionExemptions:
+  - ruleId: 'ip_addresses'
+    filePaths:
+      - '/tests/clickhouse_config_in_zookeeper_tests.py'

--- a/tests/clickhouse_config_in_zookeeper_tests.py
+++ b/tests/clickhouse_config_in_zookeeper_tests.py
@@ -1,4 +1,4 @@
-from clickhouse_config_in_zookeeper import lambda_handler, get_zookeeper_client, get_ec2_client, get_clickhouse_cluster_definition, get_graphite_rollup_xml
+from clickhouse_config_in_zookeeper import lambda_handler, get_zookeeper_client, get_ec2_client, get_clickhouse_cluster_definition
 from unittest.mock import patch, MagicMock
 import unittest, json, boto3
 
@@ -263,7 +263,6 @@ class LambdaHandler(unittest.TestCase):
         lambda_handler({}, {})
 
         zookeeper.ensure_path.assert_any_call('clickhouse.config.remote_servers')
-        zookeeper.ensure_path.assert_any_call('clickhouse.config.graphite_rollup')
 
     @patch('clickhouse_config_in_zookeeper.get_clickhouse_cluster_definition', return_value='pumpkins')
     @patch('clickhouse_config_in_zookeeper.get_zookeeper_client')
@@ -311,43 +310,8 @@ class LambdaHandler(unittest.TestCase):
   </shard>
 </hmrc_data_cluster>"""
 
-        graphite_rollup_xml = get_graphite_rollup_xml()
-
         zookeeper.set.assert_any_call('clickhouse.config.remote_servers', remote_servers_xml)
-        zookeeper.set.assert_any_call('clickhouse.config.graphite_rollup', graphite_rollup_xml)
         self.assertEqual(result, {'cluster_definition': shard_config})
-
-
-class GetGraphiteRollupXML(unittest.TestCase):
-
-    def test_get_graphite_rollup_xml(self):
-        graphite_rollup = get_graphite_rollup_xml()
-
-        graphite_rollup_xml = b"""        <path_column_name>Path</path_column_name>
-        <time_column_name>Time</time_column_name>
-        <value_column_name>Value</value_column_name>
-        <version_column_name>Timestamp</version_column_name>
-        <pattern>
-            <regexp>^collectd\..*\.mongo-.*\.(file_size-data|file_size-index|file_size-storage|gauge-collections|gauge-indexes|gauge-num_extents|gauge-object_count)$</regexp>
-            <function>avg</function>
-            <retention>
-                <age>0</age>
-                <precision>1200</precision>
-            </retention>
-        </pattern>
-        <default>
-            <function>avg</function>
-            <retention>
-                <age>0</age>
-                <precision>60</precision>
-            </retention>
-            <retention>
-                <age>604800</age>
-                <precision>600</precision>
-            </retention>
-        </default>"""
-
-        self.assertEqual(graphite_rollup_xml, graphite_rollup)
 
 class GetEC2Client(unittest.TestCase):
 

--- a/tests/clickhouse_config_in_zookeeper_tests.py
+++ b/tests/clickhouse_config_in_zookeeper_tests.py
@@ -11,9 +11,9 @@ class GetZookeeperClient(unittest.TestCase):
         ec2_client = MagicMock()
         ec2_client.describe_network_interfaces = MagicMock(return_value={
             'NetworkInterfaces': [
-                {'PrivateIpAddress': '172.26.35.126'},
-                {'PrivateIpAddress': '172.26.101.56'},
-                {'PrivateIpAddress': '172.26.38.168'}
+                {'PrivateIpAddress': '192.168.1.1'},
+                {'PrivateIpAddress': '192.168.1.2'},
+                {'PrivateIpAddress': '192.168.1.3'}
             ]
         })
 
@@ -34,7 +34,7 @@ class GetZookeeperClient(unittest.TestCase):
             }
         ])
         mock_kazoo_client.start.assert_called_once()
-        mock_kazoo_constructor.assert_called_with(hosts=['172.26.35.126', '172.26.101.56', '172.26.38.168'])
+        mock_kazoo_constructor.assert_called_with(hosts=['192.168.1.1', '192.168.1.2', '192.168.1.3'])
 
 
 


### PR DESCRIPTION
This is now put in place by Terraform, so removing from the lambda.